### PR TITLE
fix: add slash to schema links

### DIFF
--- a/app/components/content/SchemaOrgNodeList.vue
+++ b/app/components/content/SchemaOrgNodeList.vue
@@ -33,7 +33,7 @@ function normaliseToPath(s: string) {
 <template>
   <ul>
     <li v-for="(node, key) in paths" :key="key">
-      <a :href="`https://unhead.unjs.io/docs/nuxt/schema-org/api/schema${normaliseToPath(node)}`">
+      <a :href="`https://unhead.unjs.io/docs/nuxt/schema-org/api/schema/${normaliseToPath(node)}`">
         {{ node }}
       </a>
     </li>


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Node links are missing a `/` after `schema` so they are pointing to a wrong unhead.unjs.io url:

```
https://unhead.unjs.io/docs/nuxt/schema-org/api/schemajob-posting
```

Instead of 

```
https://unhead.unjs.io/docs/nuxt/schema-org/api/schema/job-posting
```

